### PR TITLE
Fix property access with never libhybris patch

### DIFF
--- a/debian/usr.bin.mediascanner-service-2.0
+++ b/debian/usr.bin.mediascanner-service-2.0
@@ -29,7 +29,7 @@
   ptrace (read) peer=@{profile_name},
 
   # attach_disconnected path
-  /dev/socket/property_service rw,
+  /{,dev/}socket/property_service rw,
 
   # Android logging triggered by platform. Can safely deny
   deny /dev/log_main w,

--- a/debian/usr.lib.mediascanner-2.0.mediascanner-extractor
+++ b/debian/usr.lib.mediascanner-2.0.mediascanner-extractor
@@ -67,7 +67,7 @@
   /{,android/}system/vendor/lib{,64}/**.so m,
 
   # attach_disconnected path
-  /dev/socket/property_service rw,
+  /{,dev/}socket/property_service rw,
 
   # Android logging triggered by platform. Can safely deny
   deny /dev/log_main w,


### PR DESCRIPTION
Newer versions of libhybris uses android's property impl, this changes the socket path
as this gets accessed on the android side of the lxc container